### PR TITLE
カラム伸縮時にバグが出る問題に対応

### DIFF
--- a/frontend/components/Comment.vue
+++ b/frontend/components/Comment.vue
@@ -254,11 +254,15 @@ export default Vue.extend({
   },
   mounted() {
     this.$props.addCallbacks(() => {
+      if (this.$refs.textarea != null) {
+        const tmp = this.$refs.textarea.clientHeight
+        this.height = tmp
+      }
+    })
+    if (this.$refs.textarea != null) {
       const tmp = this.$refs.textarea.clientHeight
       this.height = tmp
-    })
-    const tmp = this.$refs.textarea.clientHeight
-    this.height = tmp
+    }
   },
   methods: {
     LongCommentClick() {


### PR DESCRIPTION
## やったこと
- clientHeight of undefined...のバグが出るので、this.$refs.textareaのnullチェックを追加したのみ

これで該当エラーが出なくはなるが、伸縮機能自体がちゃんと働くか確認してほしい。（多分問題ないと思ってる）